### PR TITLE
[feat] Ensure input text trimming in authentication screens

### DIFF
--- a/app/screens/Login.tsx
+++ b/app/screens/Login.tsx
@@ -18,8 +18,8 @@ import { getAuthErrorMessage } from '../service/firebaseErrors';
 type TodoListProps = NativeStackScreenProps<RootStackList, 'Login'>;
 
 const Login: React.FC<TodoListProps> = ({ navigation }) => {
-  const [email, setEmail] = useState('');
-  const [password, setPassword] = useState('');
+  const [email, setEmail] = useState<string>('');
+  const [password, setPassword] = useState<string>('');
   const [error, setError] = useState<string | null>(null);
 
   const auth = FIREBASE_AUTH;
@@ -50,7 +50,7 @@ const Login: React.FC<TodoListProps> = ({ navigation }) => {
           style={styles.input}
           placeholder="Email"
           value={email}
-          onChangeText={setEmail}
+          onChangeText={(e) => setEmail(e.trim())}
           autoCapitalize="none"
           keyboardType="email-address"
         />
@@ -59,7 +59,7 @@ const Login: React.FC<TodoListProps> = ({ navigation }) => {
           placeholder="Password"
           value={password}
           secureTextEntry
-          onChangeText={setPassword}
+          onChangeText={(e) => setPassword(e.trim())}
           autoCapitalize="none"
         />
         <TouchableOpacity

--- a/app/screens/Signup.tsx
+++ b/app/screens/Signup.tsx
@@ -19,8 +19,8 @@ import { getAuthErrorMessage } from '../service/firebaseErrors';
 type TodoListProps = NativeStackScreenProps<RootStackList, 'Signup'>;
 
 const Signup: React.FC<TodoListProps> = ({ navigation }) => {
-  const [email, setEmail] = useState('');
-  const [password, setPassword] = useState('');
+  const [email, setEmail] = useState<string>('');
+  const [password, setPassword] = useState<string>('');
   const [error, setError] = useState<string | null>(null);
 
   const auth = FIREBASE_AUTH;
@@ -51,7 +51,7 @@ const Signup: React.FC<TodoListProps> = ({ navigation }) => {
           style={styles.input}
           placeholder="Email"
           value={email}
-          onChangeText={setEmail}
+          onChangeText={(e) => setEmail(e.trim())}
           autoCapitalize="none"
           keyboardType="email-address"
         />
@@ -60,7 +60,7 @@ const Signup: React.FC<TodoListProps> = ({ navigation }) => {
           placeholder="Password"
           value={password}
           secureTextEntry
-          onChangeText={setPassword}
+          onChangeText={(e) => setPassword(e.trim())}
           autoCapitalize="none"
         />
         <TouchableOpacity

--- a/app/screens/TodoDetail.tsx
+++ b/app/screens/TodoDetail.tsx
@@ -66,7 +66,7 @@ const TodoDetail = ({ route, navigation }: TodoDetailProps) => {
         <TextInput
           style={styles.input}
           value={editTodo}
-          onChangeText={setEditTodo}
+          onChangeText={(text) => setEditTodo(text.trimStart())}
           placeholder="Edit Todo Title"
           maxLength={200}
           multiline={true}


### PR DESCRIPTION
This commit adds trimming of whitespace for email and password inputs in the Login and Signup screens to enhance data consistency. Also, in TodoDetail, leading spaces are removed from the edit input for a cleaner user experience.